### PR TITLE
chore: add support for region_tags

### DIFF
--- a/apps/api-documenter/src/start.ts
+++ b/apps/api-documenter/src/start.ts
@@ -12,7 +12,7 @@ const myPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname)
 
 console.log(
   os.EOL +
-    colors.bold(`yyyyyyyyy api-documenter ${myPackageVersion} ` + colors.cyan(' - https://api-extractor.com/') + os.EOL)
+    colors.bold(`api-documenter ${myPackageVersion} ` + colors.cyan(' - https://api-extractor.com/') + os.EOL)
 );
 
 const parser: ApiDocumenterCommandLine = new ApiDocumenterCommandLine();

--- a/apps/api-extractor/src/start.ts
+++ b/apps/api-extractor/src/start.ts
@@ -9,7 +9,7 @@ import { Extractor } from './api/Extractor';
 
 console.log(
   os.EOL +
-    colors.bold(`xxxxxxxx api-extractor ${Extractor.version} ` + colors.cyan(' - https://api-extractor.com/') + os.EOL)
+    colors.bold(`api-extractor ${Extractor.version} ` + colors.cyan(' - https://api-extractor.com/') + os.EOL)
 );
 
 const parser: ApiExtractorCommandLine = new ApiExtractorCommandLine();


### PR DESCRIPTION
Resolve `region_tag` includes for samples in `@example` blocks. See https://github.com/googleapis/jsdoc-region-tag/blob/main/src/index.js