### PR TITLE
feat: error on missing region_tags instead of silent failure

### DIFF
--- a/apps/api-documenter/src/documenters/YamlDocumenter.ts
+++ b/apps/api-documenter/src/documenters/YamlDocumenter.ts
@@ -429,7 +429,7 @@ export class YamlDocumenter {
               const intro: string = match[3];
               const sample: string = sampleCache.get(key);
               if (!sample) {
-                console.warn(`could not find sample ${key}`);
+                throw new Error(`could not find sample ${key}`);
               } else {
                 const preamble: string = intro ? intro + '\n' : '';
                 example = preamble + '<pre class="prettyprint"><code>\n' + sample + '\n</pre></code>';


### PR DESCRIPTION
As discussed in the team meeting, fail if samples that are referenced via region_tags for the ref docs don't exist. 

Previous behavior is to fail silently and render the region tag name instead of the referenced code. 