### PR TITLE
fix: do not add return type for properties

### DIFF
--- a/apps/api-documenter/src/documenters/YamlDocumenter.ts
+++ b/apps/api-documenter/src/documenters/YamlDocumenter.ts
@@ -691,7 +691,9 @@ export class YamlDocumenter {
     };
     yamlItem.syntax = syntax;
 
-    if (apiItem.propertyTypeExcerpt.text) {
+    if (yamlItem.type !== 'property' && apiItem.propertyTypeExcerpt.text) {
+      // do not set a return type for properties as it will render a useless
+      // Property value box
       syntax.return = {
         type: [this._renderType(uid, apiItem.propertyTypeExcerpt)]
       };

--- a/apps/api-documenter/src/documenters/YamlDocumenter.ts
+++ b/apps/api-documenter/src/documenters/YamlDocumenter.ts
@@ -429,7 +429,7 @@ export class YamlDocumenter {
               const intro: string = match[3];
               const sample: string = sampleCache.get(key);
               if (!sample) {
-                console.warn(`could not find sample ${key}`);
+                throw new Error(`could not find sample ${key}`);
               } else {
                 const preamble: string = intro ? intro + '\n' : '';
                 example = preamble + '<pre class="prettyprint"><code>\n' + sample + '\n</pre></code>';


### PR DESCRIPTION
Class properties should not have a return type. Return types only makes sense for methods. Removing the return type from properties prevents the empty Property Values table to render in `docfx`. 

Internally see b/206851361