### PR TITLE
build: add dependency on TypeScript 4.5.x

### DIFF
--- a/apps/api-documenter/package.json
+++ b/apps/api-documenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@googleapis/api-documenter",
-  "version": "7.13.63",
+  "version": "7.13.632",
   "description": "Read JSON files from api-extractor, generate documentation pages. Fork of @microsoft/api-documenter to support GCP specific YAML requirements.",
   "repository": "googleapis/rushstack",
   "homepage": "https://api-extractor.com/",
@@ -27,6 +27,7 @@
     "@types/js-yaml": "3.12.1",
     "@types/node": "12.20.24",
     "@types/resolve": "1.17.1",
-    "jest": "~25.4.0"
+    "jest": "~25.4.0",
+    "typescript": "^4.5.0"
   }
 }


### PR DESCRIPTION
This fixes the version of TypeScript up to 4.5.x, which is the last version of TS we currently support.