### PR TITLE
fix: ensure only compatible TypeScript 4.5.x minor versions

### DIFF
--- a/apps/api-documenter/package.json
+++ b/apps/api-documenter/package.json
@@ -28,6 +28,6 @@
     "@types/node": "12.20.24",
     "@types/resolve": "1.17.1",
     "jest": "~25.4.0",
-    "typescript": "^4.5.0"
+    "typescript": "~4.5.0"
   }
 }


### PR DESCRIPTION
This changes the package.json file to constrain our TypeScript version to 4.5.x. The previous TypeScript dependency allowed for other minor versions (e.g. 4.6.0+).