### PR TITLE
build: add dependency on @microsoft/api-extractor for api-documenter

### DIFF
--- a/apps/api-documenter/package.json
+++ b/apps/api-documenter/package.json
@@ -20,6 +20,7 @@
     "resolve": "~1.17.0"
   },
   "devDependencies": {
+    "@microsoft/api-extractor": "7.18.19",
     "@rushstack/eslint-config": "^2.5.0",
     "@rushstack/heft": "^0.44.0",
     "@rushstack/heft-node-rig": "^1.3.0",


### PR DESCRIPTION
Adding dependency on @microsoft/api-extractor with the current version we support in [googleapis/nodejs-cloud-rad](https://github.com/googleapis/nodejs-cloud-rad/blob/main/api-extractor-configs/common.api.json#L4). The api-extractor version in [googleapis/nodejs-cloud-rad](https://github.com/googleapis/nodejs-cloud-rad/blob/main/package.json#L17) should also be fixed to avoid module conflicts.